### PR TITLE
Add unused -dm commandline parameter

### DIFF
--- a/bin/emu_manager.ml
+++ b/bin/emu_manager.ml
@@ -149,6 +149,9 @@ let () =
   let fork = ref true in
   let live = ref false in
 
+  (* Currently unused. *)
+  let device_model = ref "" in
+
   Arg.(parse
     [
       "-controlinfd",
@@ -182,6 +185,9 @@ let () =
         | "true" -> live := true
         | _      -> live := false),
       "Whether to save live, i.e. for a live migration";
+      "-dm",
+      Set_string device_model,
+      "Device model";
     ]
     (fun _ -> ())
     "emu-manager");


### PR DESCRIPTION
For now this is just added to prevent emu-manager from failing when this
parameter is supplied.

In future emu-manager can use this flag to tell qemu to start dirty
tracking - see https://github.com/xapi-project/xenopsd/commit/0e8624a6be6994a5aa2847147b20adcd4e32f02a#diff-356aa9d32f55797721b171382715f41f