### PR TITLE
Improve live migration

### DIFF
--- a/src/emu.h
+++ b/src/emu.h
@@ -115,6 +115,8 @@ typedef struct EmuMigrationProgress {
   // And: https://www.usenix.org/legacy/event/nsdi05/tech/full_papers/clark/clark.pdf
   int iteration;
 
+  int iterationWithoutProgress;
+
   // Used to smooth progress report when remaining is unknown.
   // See: https://github.com/xcp-ng-rpms/libempserver (emp.h => mid iteration)
   int64_t sentMidIteration;


### PR DESCRIPTION
Continue to live migrate after 50% of data. There is no reason to stop if we can continue to send RAM pages at each iteration.