### PR TITLE
Fix live migration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ cmake_minimum_required(VERSION 3.13.1)
 # Config & flags.
 # ------------------------------------------------------------------------------
 
-project(xcp-emu-manager VERSION 1.2.0 LANGUAGES C)
+project(xcp-emu-manager VERSION 1.2.1 LANGUAGES C)
 set(CMAKE_C_STANDARD 11)
 
 set(XCP_EMU_MANAGER_BIN emu-manager)

--- a/src/emu.c
+++ b/src/emu.c
@@ -258,7 +258,7 @@ static int emu_client_event_cb_emp (EmuClient *client, const char *eventType, co
   // TODO: Check better remaining value.
   if (
     iterationValue > 0 &&
-    (remainingValue <= 50 || iterationValue >= 4) &&
+    ((remainingValue >= 0 && remainingValue <= 50) || iterationValue >= 4) &&
     client->emu->state != EMU_STATE_LIVE_STAGE_DONE
   ) {
     syslog(LOG_INFO, "`%s` live stage is done!", client->emu->name);

--- a/src/emu.c
+++ b/src/emu.c
@@ -821,7 +821,7 @@ static inline int emu_manager_wait_live_stage_done () {
   return emu_manager_process(emu_process_cb_wait_live_stage_done);
 }
 
-static inline int emu_manager_migrate_paused () {
+static inline int emu_manager_migrate_pause () {
   EMU_LOG_PHASE();
 
   Emu *emu;
@@ -829,6 +829,13 @@ static inline int emu_manager_migrate_paused () {
     if ((emu->flags & EMU_FLAG_MIGRATE_PAUSED) && emu_client_send_emp_cmd(emu->client, cmd_migrate_pause, NULL) < 0)
       return -1;
 
+  return 0;
+}
+
+static inline int emu_manager_migrate_paused () {
+  EMU_LOG_PHASE();
+
+  Emu *emu;
   foreach (emu, Emus)
     if ((emu->flags & EMU_FLAG_MIGRATE_PAUSED) && emu_client_send_emp_cmd(emu->client, cmd_migrate_paused, NULL) < 0)
       return -1;
@@ -1077,6 +1084,7 @@ int emu_manager_save (bool live) {
 
   // 2. Suspend and copy the remaining dirty RAM pages in the last iteration.
   if (
+    emu_manager_migrate_pause() < 0 ||
     control_send_suspend() < 0 ||
     emu_manager_migrate_paused() < 0 ||
     emu_manager_wait_migrate_live_finished() < 0

--- a/src/main.c
+++ b/src/main.c
@@ -39,7 +39,7 @@ static int Mode = -1;
 // -----------------------------------------------------------------------------
 
 static int clean_migration (int error) {
-  if (Mode == EmuModeSave || Mode == EmuModeHvmSave)
+  if (error && (Mode == EmuModeSave || Mode == EmuModeHvmSave))
     if (emu_manager_abort_save() < 0 && !error)
       error = EmuError; // Update error only if there is no previous error!
 


### PR DESCRIPTION
This PR contains fixes to the live migration algorithm.

In the latest released version (1.2.0), the live stage always stops at the beginning of the second RAM transfer iteration.

Now we always do four iterations, or less only if the VM is idle, because the 50 dirty pages threshold to stop live migrating is **really** low.
This can reduce the downtime for VMs with huge amounts of RAM (i.e. with a long initial RAM iteration), but the overall migration time is bigger.
Part of this PR is a port of fixes brought by the people at XenServer to their version of emu-manager.
Both versions are now equivalent in terms of how they orchestrate live migration.

I experimented further with the condition to stop the live stage of migration similarly to PR #25,
but as Ronan explained elsewhere, there seems to be no reliable way of reducing the downtime in most use cases.
Maybe it's not impossible, but for now we both think it requires changes outside of emu-manager before coming back to it.

For now this is a draft PR as I'm not comfortable with the current amount of (manual) tests.
I did quite a few tests on nested hosts with small VMs and on real hosts with a 16 GB RAM VM.
I haven't seen downtime improvements compared to the current version, I think I need access to VMs with 64+ GB to confirm that.