### PR TITLE
Two live migration stability fixes

### DIFF
--- a/src/emu.c
+++ b/src/emu.c
@@ -1104,12 +1104,6 @@ int emu_manager_save (bool live) {
   return 0;
 
 fail:
-  {
-    // Cache first error.
-    int error = EmuError;
-    emu_manager_abort_save();
-    EmuError = error;
-  }
   return -1;
 }
 

--- a/src/emu.c
+++ b/src/emu.c
@@ -66,6 +66,7 @@ static Emu Emus[] = {
       EMU_FLAG_ENABLED |
       EMU_FLAG_MIGRATE_LIVE |
       EMU_FLAG_WAIT_LIVE_STAGE_DONE |
+      EMU_FLAG_MIGRATE_PAUSE |
       EMU_FLAG_MIGRATE_PAUSED,
     .state = EMU_STATE_INITIALIZED,
     .progress = { .fakeTotal = 1024 * 1024 }
@@ -75,6 +76,7 @@ static Emu Emus[] = {
     .type = EmuTypeQmpLibxl,
     .flags =
       EMU_FLAG_MIGRATE_LIVE |
+      EMU_FLAG_MIGRATE_PAUSE |
       EMU_FLAG_MIGRATE_PAUSED,
     .state = EMU_STATE_UNINITIALIZED,
     .progress = { .fakeTotal = 640 * 1024 }
@@ -821,14 +823,21 @@ static inline int emu_manager_wait_live_stage_done () {
   return emu_manager_process(emu_process_cb_wait_live_stage_done);
 }
 
-static inline int emu_manager_migrate_paused () {
+static inline int emu_manager_migrate_pause () {
   EMU_LOG_PHASE();
 
   Emu *emu;
   foreach (emu, Emus)
-    if ((emu->flags & EMU_FLAG_MIGRATE_PAUSED) && emu_client_send_emp_cmd(emu->client, cmd_migrate_pause, NULL) < 0)
+    if ((emu->flags & EMU_FLAG_MIGRATE_PAUSE) && emu_client_send_emp_cmd(emu->client, cmd_migrate_pause, NULL) < 0)
       return -1;
 
+  return 0;
+}
+
+static inline int emu_manager_migrate_paused () {
+  EMU_LOG_PHASE();
+
+  Emu *emu;
   foreach (emu, Emus)
     if ((emu->flags & EMU_FLAG_MIGRATE_PAUSED) && emu_client_send_emp_cmd(emu->client, cmd_migrate_paused, NULL) < 0)
       return -1;
@@ -1077,6 +1086,7 @@ int emu_manager_save (bool live) {
 
   // 2. Suspend and copy the remaining dirty RAM pages in the last iteration.
   if (
+    emu_manager_migrate_pause() < 0 ||
     control_send_suspend() < 0 ||
     emu_manager_migrate_paused() < 0 ||
     emu_manager_wait_migrate_live_finished() < 0

--- a/src/emu.h
+++ b/src/emu.h
@@ -42,9 +42,13 @@ extern __thread int EmuError;
 // Live stage is done when it remains very few dirty pages to move.
 #define EMU_FLAG_WAIT_LIVE_STAGE_DONE (1 << 2)
 
-// Request the pause status for one emu. I.e. no data can be written by this emu.
-// Must be used after a migrate live call to migrate the remaining dirty pages.
-#define EMU_FLAG_MIGRATE_PAUSED (1 << 3)
+// Request the pause status for one emu. I.e. no further writes to its RAM may be made.
+// Must be used after a migrate live call.
+#define EMU_FLAG_MIGRATE_PAUSE (1 << 3)
+
+// Emu is paused. No further writes to its RAM are expected.
+// Must be used after a migrate pause call to migrate the remaining dirty pages.
+#define EMU_FLAG_MIGRATE_PAUSED (1 << 4)
 
 // Emu is migrated directly. More violent than live mode.
 #define EMU_FLAG_MIGRATE_NON_LIVE (1 << 5)

--- a/src/main.c
+++ b/src/main.c
@@ -39,12 +39,11 @@ static int Mode = -1;
 // -----------------------------------------------------------------------------
 
 static int clean_migration (int error) {
-  if (Mode == EmuModeSave || Mode == EmuModeHvmSave)
-    if (emu_manager_abort_save() < 0 && !error)
-      error = EmuError; // Update error only if there is no previous error!
+  if (error && (Mode == EmuModeSave || Mode == EmuModeHvmSave))
+    emu_manager_abort_save(); // Don't update previous error.
 
   if (emu_manager_disconnect() < 0 && !error)
-    error = EmuError; // Same idea.
+    error = EmuError; // Update error only if there is no previous error.
 
   // Ignore errors of emu_manager_wait_termination.
   emu_manager_wait_termination();


### PR DESCRIPTION
**Fix: remove unnecessary or duplicate abort commands**

With commit 8515617c8247c62e24b533afe3ee64d71bfd51c5, emu-manager won't send an abort migration command after the migration succeeded.
Literally, this means we avoid triggering [this function](https://github.com/xenserver/xen.pg/blob/XS-8.4/patches/xenguest.patch#L2702-L2707) after the end of the successful migration,
which has no effects at this stage anyway.

With commit a5f09b49b3f730945aeec8f3adba604750808a9f, emu-manager won't send an abort command twice if the migration fails.

Tested ten times when migration succeeded in various situations.
Checked the number of abort commands and the error reported to xenopsd when there is a migration failure from either:
- the crash handler (killed by a signal)
- an issue in the save routine (injected an error in-code)

Also checked the migration error isn't overwritten by the abort error if both failed.

**Fix: send cmd_migrate_pause before suspending the domain**

With this fix, emu-manager sends the pause command sooner (asap) when it decided the live stage of migration should end.
The current emu-manager waits for xenopsd to suspend the domain before sending this pause command,
but [libxenguest's migration loop](https://elixir.bootlin.com/xen/v4.20.1/source/tools/libs/guest/xg_sr_save.c#L495) keeps running during this time, meaning the migration can reach up to 280 live iterations
when ~20 pages are dirtied during each iteration (I encountered this case very quickly with idle VMs).

This fix is also present in XenServer's emu-manager [with this commit](https://github.com/xenserver/emu-manager/commit/c3a0bfba68cd8529974bf96c925ad11f3c4c404e), but there is one difference:
XS: send pause command before suspending the domain, if it fails fallback to sending the pause command after suspending
XCP: send pause command before suspending the domain, no fallback
That's simply because our save routine aborts the migration when any step fails, so I kept it consistent.

Tested ten times when migration succeeded in various situations.
In terms of the performance impact I only made one test with a VM migrated at low and high RAM usage without storage migration.
With this fix I reduced the downtime by 13s (from 55s to 42s) with ~7.5 GBit/s of RAM usage, but it needs more tests to validate this result, and also tests with more complex scenarios.